### PR TITLE
fix: モバイル版公開アーティストリストページの表示が崩れている不具合を修正

### DIFF
--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     {{-- アーティスト一覧の全体 --}}
     <div class="w-screen p-2 flex flex-col items-center justify-center">
-        <div class="mt-8 p-6 lg:w-1/3 flex flex-col items-center justify-center bg-white rounded-lg drop-shadow">
+        <div class="mt-8 p-6 w-full lg:w-1/3 flex flex-col items-center justify-center bg-white rounded-lg drop-shadow">
             {{-- ユーザー名 --}}
             <div class="">
                 <p class="text-4xl font-semibold text-gray-900 dark:text-white">{{ $user_name }}</p>


### PR DESCRIPTION
### 概要
モバイル版の公開アーティストリストページの表示が崩れている不具合を修正

### 変更内容
- 公開アーティストリストページのアーティストリスト全体を囲う要素に対して`w-full`の記述が不足していたミスを修正